### PR TITLE
USWDS-Site - Implementations: Salesforce Lightning is Archived

### DIFF
--- a/_data/implementations.yml
+++ b/_data/implementations.yml
@@ -160,6 +160,7 @@
 - name: uswds-sf-lightning-community
   distribution: Salesforce Lightning
   url: https://github.com/GSA/uswds-sf-lightning-community
+  status: archived
   author:
     name: GSA IT (Mark Vogelgesang)
     url: https://github.com/GSA/


### PR DESCRIPTION
# Summary

The Salesforce Lightning implementation of USWDS was archived in January 2024 this year:
https://github.com/GSA/uswds-sf-lightning-community

This pull request marks that implementation as "archived" on the Implementations page.